### PR TITLE
Add cookie policy and banner

### DIFF
--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,0 +1,37 @@
+export const metadata = {
+  title: "Cookie Richtlinie",
+};
+
+export default function CookiePolicy() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 text-[#334269] space-y-4">
+      <h1 className="text-3xl font-bold">Cookie Richtlinie</h1>
+      <p>
+        Diese Anwendung nutzt Supabase Auth für die Anmeldung über Google,
+        Facebook und Magic Links. Die von Ihnen im Dashboard getätigten
+        Einstellungen werden in einer Datenbank gespeichert und können mit
+        Ihrem Instagram Konto verbunden werden, um Direktnachrichten und
+        Kommentare automatisch zu beantworten.
+      </p>
+      <p>
+        Wir verwenden folgende Arten von Cookies:
+      </p>
+      <ul className="list-disc pl-6 space-y-2">
+        <li><strong>Funktionale Cookies</strong> – notwendig, damit die Seite ordnungsgemäß funktioniert.</li>
+        <li><strong>Analytische Cookies</strong> – helfen uns zu verstehen, wie die Seite genutzt wird.</li>
+        <li><strong>Marketing Cookies</strong> – dienen dazu, Ihnen relevante Angebote zu zeigen.</li>
+      </ul>
+      <p>
+        Ihre Auswahl wird im Local Storage Ihres Browsers gespeichert. Zudem
+        halten wir in einem lokalen Protokoll fest, wann und mit welchen
+        Optionen Sie zugestimmt oder abgelehnt haben. Dieses Protokoll wird
+        nicht an den Server übertragen.
+      </p>
+      <p>
+        Sie können Ihre Entscheidung jederzeit löschen, indem Sie den Local
+        Storage Ihres Browsers leeren. Beim nächsten Besuch erscheint der
+        Banner erneut.
+      </p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Dialog, DialogTrigger, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import AuthForm from '@/components/auth/AuthForm';
 import { createClient } from '@/lib/auth/supabaseClient.client';
+import CookieBanner from '@/components/CookieBanner';
 
 export default function LandingPage() {
   const router = useRouter();
@@ -106,6 +107,7 @@ export default function LandingPage() {
           </div>
         </div>
       </section>
+      <CookieBanner />
     </div>
   );
 }

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,108 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+
+interface Consent {
+  functional: boolean;
+  analytics: boolean;
+  marketing: boolean;
+  timestamp: string;
+}
+
+const CONSENT_KEY = "cookieConsent";
+const CONSENT_LOG_KEY = "cookieConsentLog";
+
+export default function CookieBanner() {
+  const [open, setOpen] = useState(false);
+  const [analytics, setAnalytics] = useState(false);
+  const [marketing, setMarketing] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(CONSENT_KEY);
+    if (!stored) {
+      setOpen(true);
+    }
+  }, []);
+
+  const saveConsent = (consent: Consent, action: string) => {
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(consent));
+    const existing = localStorage.getItem(CONSENT_LOG_KEY);
+    const log = existing ? JSON.parse(existing) : [];
+    log.push({ ...consent, action });
+    localStorage.setItem(CONSENT_LOG_KEY, JSON.stringify(log));
+  };
+
+  const handleAccept = () => {
+    const consent = {
+      functional: true,
+      analytics,
+      marketing,
+      timestamp: new Date().toISOString(),
+    };
+    saveConsent(consent, "accept");
+    setOpen(false);
+  };
+
+  const handleDecline = () => {
+    const consent = {
+      functional: true,
+      analytics: false,
+      marketing: false,
+      timestamp: new Date().toISOString(),
+    };
+    saveConsent(consent, "decline");
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-80">
+      <div className="bg-[#15192a]/90 text-[#a3bffa] p-4 rounded-lg shadow-xl text-sm">
+        <h3 className="font-bold mb-2 text-base">Cookie Nutzung</h3>
+        <p className="mb-3">Wir verwenden funktionale, analytische und Marketing Cookies.</p>
+        <div className="flex flex-col gap-1 mb-3">
+          <label className="flex items-center gap-2">
+            <input type="checkbox" checked disabled className="accent-blue-500" />
+            Funktionale Cookies (erforderlich)
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={analytics}
+              onChange={(e) => setAnalytics(e.target.checked)}
+              className="accent-blue-500"
+            />
+            Analytische Cookies
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={marketing}
+              onChange={(e) => setMarketing(e.target.checked)}
+              className="accent-blue-500"
+            />
+            Marketing Cookies
+          </label>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={handleDecline}
+            className="px-3 py-1 rounded-md bg-gray-700/40 hover:bg-gray-700"
+          >
+            Ablehnen
+          </button>
+          <button
+            onClick={handleAccept}
+            className="px-3 py-1 rounded-md bg-[#a3bffa] text-[#334269] font-semibold hover:bg-[#f3aacb]"
+          >
+            Akzeptieren
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-right">
+          <Link href="/cookie-policy" className="underline">Mehr erfahren</Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a persistent cookie banner to collect consent
- add a cookie policy page explaining the cookie categories
- render the banner on the landing page

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: `next` not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_b_6870efa23740832fbd86c8b328c14bf7