### PR TITLE
Implement Supabase register endpoint

### DIFF
--- a/src/lib/auth/supabaseAuth.ts
+++ b/src/lib/auth/supabaseAuth.ts
@@ -1,38 +1,34 @@
 import { createClient } from '@supabase/supabase-js'
 
-export async function signUp(email: string, password: string) {
-  const supabaseUrl = 'https://beydpbnwneqksnmnlcce.supabase.co'
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY
-  const supabase = createClient(supabaseUrl, supabaseKey!)
 
-  // 1. Register with Supabase Auth
-  const { error, data } = await supabase.auth.signUp({ email, password });
-  if (error) return { error };
-
-  // 2. Register in local DB
+export async function register(email: string, password: string) {
   const res = await fetch('/api/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),
   });
+  const result = await res.json();
   if (!res.ok) {
-    const err = await res.json();
-    return { error: { message: err.message || 'Failed to register in local DB' } };
+    return { error: { message: result.message || 'Failed to register' } };
   }
-  return { data };
+  return { data: result };
+}
+
+export async function signUp(email: string, password: string) {
+  return register(email, password);
 }
 
 export async function signIn(email: string, password: string) {
-  const supabaseUrl = 'https://beydpbnwneqksnmnlcce.supabase.co'
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY
-  const supabase = createClient(supabaseUrl, supabaseKey!)
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const supabase = createClient(supabaseUrl, supabaseKey)
 
   return supabase.auth.signInWithPassword({ email, password });
 }
 
 export async function signOut() {
-  const supabaseUrl = 'https://beydpbnwneqksnmnlcce.supabase.co'
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY
-  const supabase = createClient(supabaseUrl, supabaseKey!)
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const supabase = createClient(supabaseUrl, supabaseKey)
   return supabase.auth.signOut();
 } 


### PR DESCRIPTION
## Summary
- handle Supabase sign-up in the `register` API route
- store Supabase user id in the local users table
- expose a `register` helper in `supabaseAuth`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687102648a84832f820769b889231549